### PR TITLE
Added support for rediss url strings

### DIFF
--- a/src/konserve_redis/core.clj
+++ b/src/konserve_redis/core.clj
@@ -16,7 +16,8 @@
 (defn redis-client
   [opts]
   {:pool (car/connection-pool (or (:pool opts) {}))
-   :spec {:uri (:uri opts)}})
+   :spec {:uri (:uri opts)
+          :ssl-fn :default}})
 
 (defn put-object [client ^String key ^bytes bytes]
   (wcar client (car/set key bytes)))


### PR DESCRIPTION
Rediss is supported by Carmine now and it requires a simple additional key to the connection map. Adding it to the default map will save users time trying to track down why their otherwise correct connection string is not working.